### PR TITLE
Criando teste unitário método getEstatisticasClientes

### DIFF
--- a/src/test/java/api/dashboard/model/services/impl/ClienteServiceImplTest.java
+++ b/src/test/java/api/dashboard/model/services/impl/ClienteServiceImplTest.java
@@ -1,0 +1,66 @@
+package api.dashboard.model.services.impl;
+
+import api.dashboard.exceptions.ZeroRegistrosEncontradosException;
+import api.dashboard.model.dtos.response.EstatisticasDTO;
+import api.dashboard.utilities.clientes.AcessoDadosCliente;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+class ClienteServiceImplTest {
+
+  @InjectMocks
+  private ClienteServiceImpl service;
+  @Mock
+  private AcessoDadosCliente acessoDadosCliente;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    startEntities();
+  }
+
+  @Test
+  void whenGetEstatisticasClientesThenReturnSuccess() {
+    when(acessoDadosCliente.getTotalRegistrosCadastrados()).thenReturn(100);
+    when(acessoDadosCliente.getRegistrosCadastradosUltimos30Dias()).thenReturn(15);
+    when(acessoDadosCliente.getRegistrosCadastradosEntreUltimos30E60Dias()).thenReturn(10);
+
+    var content = service.getEstatisticasClientes();
+
+    assertEquals(HttpStatus.OK, content.getStatusCode());
+    assertEquals(EstatisticasDTO.class, content.getBody().getClass());
+    assertEquals("Clientes", content.getBody().getNomeEntidade());
+    assertEquals(100, content.getBody().getTotal());
+    assertEquals(50.0d, content.getBody().getCrescimento());
+  }
+
+  @Test
+  void whenGetEstatisticasClientesThenReturnZeroRegistrosEncontradosException() {
+    when(acessoDadosCliente.getTotalRegistrosCadastrados()).thenReturn(100);
+    when(acessoDadosCliente.getRegistrosCadastradosUltimos30Dias()).thenReturn(15);
+    // O método lança a exception quando não houverem clientes cadastrados no mês retrasado a partir da data atual.
+    // Por que a divisão no calculo é feita por 0.
+    when(acessoDadosCliente.getRegistrosCadastradosEntreUltimos30E60Dias()).thenReturn(0);
+
+    try {
+      service.getEstatisticasClientes();
+    } catch (Exception ex) {
+      assertEquals(ZeroRegistrosEncontradosException.class, ex.getClass());
+      assertEquals("Não há registros cadastrados no penúltimo mês!", ex.getMessage());
+    }
+  }
+
+  public void startEntities() {}
+}


### PR DESCRIPTION
Criei o teste unitário que valida os dois cenários que esse método pode seguir. O primeiro cenário é quando a operação é efetuada com sucesso. Neste caso, a classe de acesso aos dados do banco de dados de clientes retorna registros validos e o calculo do crescimento de clientes é feito. O segundo cenário é quando não há clientes cadastrados no mês retrasado a partir da data que o endpoint foi chamado. Neste caso, não é possivel realizar o calculo do crescimento por que a divisão seria feita por 0. Neste cenário, uma exception é lançada pela API.