### PR TITLE
Feature/endpoint get estatisticas clientes by mes

### DIFF
--- a/src/main/java/api/dashboard/controllers/ClienteRestController.java
+++ b/src/main/java/api/dashboard/controllers/ClienteRestController.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -49,5 +50,12 @@ public class ClienteRestController {
     return service.getEstatisticasClientes();
   }
 
+  @GetMapping("/buscas/getEstatisticasClientesByMes")
+  public ResponseEntity<EstatisticasDTO> getEstatisticasClientesByMes(
+          @RequestParam(name = "mes", defaultValue = "1") Integer mes
+  ) {
+
+    return service.getEstatisticasClientesByMes(mes);
+  }
 
 }

--- a/src/main/java/api/dashboard/exceptions/ZeroCountException.java
+++ b/src/main/java/api/dashboard/exceptions/ZeroCountException.java
@@ -1,0 +1,9 @@
+package api.dashboard.exceptions;
+
+public class ZeroCountException extends RuntimeException {
+
+  public ZeroCountException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/api/dashboard/exceptions/controllers/ExceptionHandlerController.java
+++ b/src/main/java/api/dashboard/exceptions/controllers/ExceptionHandlerController.java
@@ -1,9 +1,11 @@
 package api.dashboard.exceptions.controllers;
 
 import api.dashboard.exceptions.ExceptionResponse;
+import api.dashboard.exceptions.ZeroCountException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -13,6 +15,11 @@ import java.util.Date;
 @RestController
 @ControllerAdvice
 public class ExceptionHandlerController extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler(ZeroCountException.class)
+  public ResponseEntity<ExceptionResponse> zeroCountException(Exception ex, WebRequest request) {
+    return criarERetornarExceptionResponse(ex, request, HttpStatus.NOT_FOUND);
+  }
 
   public ResponseEntity<ExceptionResponse> criarERetornarExceptionResponse(Exception ex,
                                                                            WebRequest request,

--- a/src/main/java/api/dashboard/model/repositories/ClienteRepository.java
+++ b/src/main/java/api/dashboard/model/repositories/ClienteRepository.java
@@ -15,12 +15,12 @@ public interface ClienteRepository extends JpaRepository<Cliente, Long> {
           "WHERE c.dataCriacao >= :umMesAtras")
   Integer countClienteLast30DaysByDataCriacao(@PathParam("umMesAtras") LocalDate umMesAtras);
 
-  @Query("SELECT COUNT(c) FROM Cliente c " +
-          "WHERE c.dataCriacao >= :doisMesesAtras " +
-          "AND c.dataCriacao <= :umMesAtras")
-  Integer countClienteBetween2DatesByDataCriacao(@PathParam("umMesAtras") LocalDate doisMesesAtras,
-                                                 @PathParam("doisMesesAtras") LocalDate umMesAtras);
-
   @Query("SELECT COUNT(*) FROM Cliente")
   Integer countTotalClientesByDataCriacao();
+
+  @Query("SELECT COUNT(c) FROM Cliente c " +
+          "WHERE c.dataCriacao >= :dataInicial " +
+          "AND c.dataCriacao <= :dataFinal")
+  Integer countClienteBetween2Dates(@PathParam("dataInicio") LocalDate dataInicial,
+                                    @PathParam("dataFinal") LocalDate dataFinal);
 }

--- a/src/main/java/api/dashboard/model/services/ClienteService.java
+++ b/src/main/java/api/dashboard/model/services/ClienteService.java
@@ -6,5 +6,6 @@ import org.springframework.http.ResponseEntity;
 public interface ClienteService {
 
   ResponseEntity<EstatisticasDTO> getEstatisticasClientes();
+  ResponseEntity<EstatisticasDTO> getEstatisticasClientesByMes(Integer valorMes);
 
 }

--- a/src/main/java/api/dashboard/model/services/impl/ClienteServiceImpl.java
+++ b/src/main/java/api/dashboard/model/services/impl/ClienteServiceImpl.java
@@ -27,4 +27,14 @@ public class ClienteServiceImpl implements ClienteService {
     return new ResponseEntity<>(estatisticasDTO, HttpStatus.OK);
   }
 
+  public ResponseEntity<EstatisticasDTO> getEstatisticasClientesByMes(Integer valorMes) {
+    Integer totalClientes = acessoDadosCliente.getRegistrosCadastradosMesEspecifico(valorMes);
+    Double porcentagemCrescimentoUltimoMesEmRelacaoAoMesSelecionado = new Calculos(acessoDadosCliente)
+            .calcularCrescimentoUltimoMesEmRelacaoAMesSelecionado(valorMes);
+    EstatisticasDTO estatisticasDTO = EstatisticasDTO.newEstatisticasDTO(
+            "Clientes", totalClientes, porcentagemCrescimentoUltimoMesEmRelacaoAoMesSelecionado);
+
+    return new ResponseEntity<>(estatisticasDTO, HttpStatus.OK);
+  }
+
 }

--- a/src/main/java/api/dashboard/utilities/Calculos.java
+++ b/src/main/java/api/dashboard/utilities/Calculos.java
@@ -1,5 +1,6 @@
 package api.dashboard.utilities;
 
+import api.dashboard.exceptions.ZeroCountException;
 import api.dashboard.utilities.interfaces.CalculosInterface;
 import api.dashboard.utilities.interfaces.searches.AcessoDados;
 
@@ -16,6 +17,20 @@ public class Calculos implements CalculosInterface {
     Integer registrosCadastradosUltimoMes = acessoDados.getRegistrosCadastradosUltimoMes();
 
     return (double) (registrosCadastradosUltimoMes * 100) / registrosCadastradosTotal;
+  }
+
+  public Double calcularCrescimentoUltimoMesEmRelacaoAMesSelecionado(Integer valorMes) {
+    Integer registrosCadastradosUltimoMes = acessoDados.getRegistrosCadastradosUltimoMes();
+    Integer registrosCadastradosMesSelecionado = acessoDados.getRegistrosCadastradosMesEspecifico(valorMes);
+    validarTotalRegistrosCadastrados(registrosCadastradosMesSelecionado);
+    Integer diferencaDeCadastros = registrosCadastradosUltimoMes - registrosCadastradosMesSelecionado;
+
+    return (double) (diferencaDeCadastros * 100) / registrosCadastradosMesSelecionado;
+  }
+
+  private void validarTotalRegistrosCadastrados(Integer totalRegistros) {
+    if (totalRegistros == 0)
+      throw new ZeroCountException("Dados insuficientes!");
   }
 
 }

--- a/src/main/java/api/dashboard/utilities/GeracaoDatas.java
+++ b/src/main/java/api/dashboard/utilities/GeracaoDatas.java
@@ -1,22 +1,28 @@
 package api.dashboard.utilities;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Component;
-
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-@Component
 public class GeracaoDatas {
 
-  private LocalDate hoje = LocalDate.now();
-  private LocalDate umMesAtras = hoje.plusMonths(-1);
-  private LocalDate doisMesesAtras = umMesAtras.plusMonths(-1);
+  public static LocalDate getHoje() {
+    return LocalDate.now();
+  }
+
+  public static Integer getAnoAtual() {
+    return getHoje().getYear();
+  }
+
+  public static LocalDate getUmMesAtras() {
+    return getHoje().plusMonths(-1);
+  }
+
+  public static LocalDate getDataPersonalizada(Integer ano, Integer mes, Integer dia) {
+    return LocalDate.of(ano, mes, dia);
+  }
+
+  public static LocalDate getUltimoDiaMes(LocalDate data) {
+    return data.with(TemporalAdjusters.lastDayOfMonth());
+  }
 
 }

--- a/src/main/java/api/dashboard/utilities/clientes/AcessoDadosCliente.java
+++ b/src/main/java/api/dashboard/utilities/clientes/AcessoDadosCliente.java
@@ -5,25 +5,30 @@ import api.dashboard.utilities.GeracaoDatas;
 import api.dashboard.utilities.interfaces.searches.AcessoDados;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+
 @Component
 public class AcessoDadosCliente implements AcessoDados {
 
   private ClienteRepository repository;
-  private GeracaoDatas geracaoDatas;
 
-  public AcessoDadosCliente(ClienteRepository repository,
-                            GeracaoDatas geracaoDatas) {
-
+  public AcessoDadosCliente(ClienteRepository repository) {
     this.repository = repository;
-    this.geracaoDatas = geracaoDatas;
   }
 
   public Integer getRegistrosCadastradosUltimoMes() {
-    return repository.countClienteLast30DaysByDataCriacao(geracaoDatas.getUmMesAtras());
+    return repository.countClienteLast30DaysByDataCriacao(GeracaoDatas.getUmMesAtras());
   }
 
   public Integer getTotalRegistrosCadastrados() {
     return repository.countTotalClientesByDataCriacao();
+  }
+
+  public Integer getRegistrosCadastradosMesEspecifico(Integer valorMes) {
+    LocalDate primeiroDiaDoMes = GeracaoDatas.getDataPersonalizada(GeracaoDatas.getAnoAtual(), valorMes, 01);
+    LocalDate ultimoDiaDoMes = GeracaoDatas.getUltimoDiaMes(primeiroDiaDoMes);
+
+    return repository.countClienteBetween2Dates(primeiroDiaDoMes, ultimoDiaDoMes);
   }
 
 }

--- a/src/main/java/api/dashboard/utilities/interfaces/CalculosInterface.java
+++ b/src/main/java/api/dashboard/utilities/interfaces/CalculosInterface.java
@@ -3,5 +3,6 @@ package api.dashboard.utilities.interfaces;
 public interface CalculosInterface {
 
   Double calcularCrescimentoUltimoMesEmRelacaoAoTotal();
+  Double calcularCrescimentoUltimoMesEmRelacaoAMesSelecionado(Integer valorMes);
 
 }

--- a/src/main/java/api/dashboard/utilities/interfaces/searches/AcessoDados.java
+++ b/src/main/java/api/dashboard/utilities/interfaces/searches/AcessoDados.java
@@ -4,5 +4,6 @@ public interface AcessoDados {
 
   Integer getRegistrosCadastradosUltimoMes();
   Integer getTotalRegistrosCadastrados();
+  Integer getRegistrosCadastradosMesEspecifico(Integer valorMes);
 
 }


### PR DESCRIPTION
Nessa branch foi desenvolvida toda a lógica do endpoint getEstatisticasClientesByMes.
Esse endpoint será chamado sempre que o usuário quiser coletar informações como:
- Total de clientes cadastrados em um mês especifico;
- Porcentagem de crescimento de cadastros de clientes nos ultimos 30 dias em relação a quantidade de clientes cadastrados nesse mês especifico.

A lógica do endpoint é:
O cliente faz a requisição passando um numero de mês (1, 2, 3, 4 etc.) como requestParam.
A API recebe esse numero de mês e puxa todos os clientes cadastrados naquele mês.
A API puxa também o total de clientes cadastrados nos ultimos 30 dias.
Após isso, ela realiza um calculo do crescimento descrito anteriormente.

Com esses valores, um objeto EstatisticasDTO é criado recebendo os seguintes atributos:
- nomeEntidade: Esse é o nome da entidade que está sendo tratada no momento, no caso 'Clientes'
- total: Esse é o total de clientes cadastrados no mês selecionado
- crescimento: Essa é a porcentagem de crescimento nos ultimos 30 dias em relação ao mês selecionado.

Esse objeto é retornado em um ResponseEntity com o codigo HTTP 200