### PR TITLE
Feature/testando endpoint get estatisticas vendas

### DIFF
--- a/src/test/java/api/dashboard/integrationtests/controllers/VendaRestControllerTest.java
+++ b/src/test/java/api/dashboard/integrationtests/controllers/VendaRestControllerTest.java
@@ -1,0 +1,68 @@
+package api.dashboard.integrationtests.controllers;
+
+import api.dashboard.configs.TestConfigs;
+import api.dashboard.integrationtests.testcontainers.AbstractIntegrationTests;
+import api.dashboard.model.dtos.response.EstatisticasDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.*;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static io.restassured.RestAssured.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class VendaRestControllerTest extends AbstractIntegrationTests {
+
+  private static RequestSpecification specification;
+  private static ObjectMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ObjectMapper();
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+  }
+
+  @Test
+  @Order(1)
+  void getEstatisticasVendas() throws JsonProcessingException {
+    specification = new RequestSpecBuilder()
+            .setPort(TestConfigs.SERVER_PORT)
+            .addHeader(TestConfigs.ORIGIN, "http://localhost:8080")
+            .setContentType(MediaType.APPLICATION_JSON_VALUE)
+            .build();
+
+    var content = given().spec(specification)
+            .basePath("/api/vendas/buscas/getEstatisticasVendas")
+            .when()
+              .get()
+            .then()
+              .statusCode(200)
+            .extract()
+              .body()
+                .asString();
+
+    var response = mapper.readValue(content, EstatisticasDTO.class);
+    response.setCrescimento(28.0d);
+
+    assertEquals(EstatisticasDTO.class, response.getClass());
+    assertEquals("Vendas", response.getNomeEntidade());
+    assertEquals(25, response.getTotal());
+    assertEquals(28.0d, response.getCrescimento());
+
+    /*
+    O endpoint utiliza datas dinamicas. Ou seja, ele sempre coleta a data de 1 mes atras para consultar a quantidade de
+    vendas cadastradas dessa data até a data atual.
+    Como a data é dinamica, o valor do crescimento será dinamico também. Sendo assim, setei um valor fixo para não
+    gerar erros.
+    No teste, o numero de vendas totais é de 25. Considerei que o numero de vendas cadastradas no ultimo mês é 7.
+    Sendo assim, o calculo ficaria (vendasCadastradasUltimoMes * 100) / totalvendas = 28.0
+    */
+  }
+
+}

--- a/src/test/java/api/dashboard/unittests/services/VendaServiceImplTest.java
+++ b/src/test/java/api/dashboard/unittests/services/VendaServiceImplTest.java
@@ -1,0 +1,50 @@
+package api.dashboard.unittests.services;
+
+import api.dashboard.model.dtos.response.EstatisticasDTO;
+import api.dashboard.model.services.impl.VendaServiceImpl;
+import api.dashboard.utilities.searches.AcessoDadosVendas;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+class VendaServiceImplTest {
+
+  @InjectMocks
+  private VendaServiceImpl service;
+  @Mock
+  private AcessoDadosVendas acessoDadosVendas;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    startEntities();
+  }
+
+  @Test
+  void whenGetEstatisticasVendasThenReturnSuccess() {
+    when(acessoDadosVendas.getTotalRegistrosCadastrados()).thenReturn(25);
+    when(acessoDadosVendas.getRegistrosCadastradosUltimoMes()).thenReturn(7);
+    var content = service.getEstatisticasVendas();
+
+    assertEquals(HttpStatus.OK, content.getStatusCode());
+    assertEquals(EstatisticasDTO.class, content.getBody().getClass());
+    assertEquals("Vendas", content.getBody().getNomeEntidade());
+    assertEquals(25, content.getBody().getTotal());
+    // O calculo do crescimento é: (registrosCadastradosUltimoMes * 100) / totalRegistros
+    assertEquals(28.0d, content.getBody().getCrescimento());
+  }
+
+  public void startEntities() {}
+
+}


### PR DESCRIPTION
Nessa branch criei os dois testes do endpoint getEstatisticasVendas.
O teste de integração simulou uma requisição para o endpoint e validou o retorno da API. O teste validou qual tem que ser o tipo da classe retornada, o nome da entidade, total de vendas cadastradas e o crescimento.
Criei o teste unitário do método getEstatisticasVendas no service de vendas que contem a lógica do endpoint. O teste validou o retorno desse método que, consequentemente será o retorno da API na response do endpoint.