### PR TITLE
Feature/criando endpoint get estatisticas veiculos by mes

### DIFF
--- a/src/main/java/api/dashboard/controllers/VeiculoRestController.java
+++ b/src/main/java/api/dashboard/controllers/VeiculoRestController.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -46,6 +47,13 @@ public class VeiculoRestController {
   @GetMapping("/buscas/getEstatisticasVeiculos")
   public ResponseEntity<EstatisticasDTO> getEstatisticasVeiculos() {
     return service.getEstatisticasVeiculos();
+  }
+
+  @GetMapping("/buscas/getEstatisticasVeiculosByMes")
+  public ResponseEntity<EstatisticasDTO> getEstatisticasVeiculosByMes(
+          @RequestParam(name = "mes", defaultValue = "1") Integer mes) {
+
+    return service.getEstatisticasVeiculosByMes(mes);
   }
 
 }

--- a/src/main/java/api/dashboard/controllers/VeiculoRestController.java
+++ b/src/main/java/api/dashboard/controllers/VeiculoRestController.java
@@ -1,5 +1,6 @@
 package api.dashboard.controllers;
 
+import api.dashboard.exceptions.ExceptionResponse;
 import api.dashboard.model.dtos.response.EstatisticasDTO;
 import api.dashboard.model.services.impl.VeiculoServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,6 +50,33 @@ public class VeiculoRestController {
     return service.getEstatisticasVeiculos();
   }
 
+  @Operation(summary = "Coletar estatisticas dos veículos por mês",
+    description = "Coletar total de veículos cadastradas no sistema filtrando por um mês e a porcentagem " +
+            "de crescimento das veículos cadastradas no ultimo mês em relação ao total cadastrada no mês selecionado.",
+    tags = {"Busca"},
+    responses = {
+      @ApiResponse(description = "Sucesso", responseCode = "200",
+        content = {
+          @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = EstatisticasDTO.class)
+          )
+        }
+      ),
+      @ApiResponse(description = "Zero veículos cadastrados no mês selecionado", responseCode = "404",
+        content = {
+          @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ExceptionResponse.class)
+          )
+        }
+      ),
+      @ApiResponse(description = "Bad Request", responseCode = "400", content = @Content),
+      @ApiResponse(description = "Unauthorized", responseCode = "401", content = @Content),
+      @ApiResponse(description = "Forbiden", responseCode = "403", content = @Content),
+      @ApiResponse(description = "Internal Server Error", responseCode = "500", content = @Content)
+    }
+  )
   @GetMapping("/buscas/getEstatisticasVeiculosByMes")
   public ResponseEntity<EstatisticasDTO> getEstatisticasVeiculosByMes(
           @RequestParam(name = "mes", defaultValue = "1") Integer mes) {

--- a/src/main/java/api/dashboard/model/repositories/VeiculoRepository.java
+++ b/src/main/java/api/dashboard/model/repositories/VeiculoRepository.java
@@ -18,4 +18,10 @@ public interface VeiculoRepository extends JpaRepository<Veiculo, Long> {
   @Query("SELECT COUNT(*) FROM Veiculo")
   Integer countTotalVeiculosByDataCriacao();
 
+  @Query("SELECT COUNT(v) FROM Veiculo v " +
+          "WHERE v.dataCriacao >= :dataInicial " +
+          "AND v.dataCriacao <= :dataFinal")
+  Integer countVeiculoBetween2Dates(@PathParam("dataInicial") LocalDate dataInicial,
+                                    @PathParam("dataFinal") LocalDate dataFinal);
+
 }

--- a/src/main/java/api/dashboard/model/services/VeiculoService.java
+++ b/src/main/java/api/dashboard/model/services/VeiculoService.java
@@ -6,5 +6,6 @@ import org.springframework.http.ResponseEntity;
 public interface VeiculoService {
 
   ResponseEntity<EstatisticasDTO> getEstatisticasVeiculos();
+  ResponseEntity<EstatisticasDTO> getEstatisticasVeiculosByMes(Integer valorMes);
 
 }

--- a/src/main/java/api/dashboard/model/services/impl/VeiculoServiceImpl.java
+++ b/src/main/java/api/dashboard/model/services/impl/VeiculoServiceImpl.java
@@ -28,4 +28,15 @@ public class VeiculoServiceImpl implements VeiculoService {
     return new ResponseEntity<>(estatisticasDTO, HttpStatus.OK);
   }
 
+  @Override
+  public ResponseEntity<EstatisticasDTO> getEstatisticasVeiculosByMes(Integer valorMes) {
+    Integer totalVeiculos = acessoDadosVeiculos.getRegistrosCadastradosMesEspecifico(valorMes);
+    Double porcentagemCrescimentoUltimoMesEmRelacaoAoMesSelecionado = new Calculos(acessoDadosVeiculos)
+            .calcularCrescimentoUltimoMesEmRelacaoAMesSelecionado(valorMes);
+    EstatisticasDTO estatisticasDTO = EstatisticasDTO.newEstatisticasDTO(
+            "Veículos", totalVeiculos, porcentagemCrescimentoUltimoMesEmRelacaoAoMesSelecionado);
+
+    return new ResponseEntity<>(estatisticasDTO, HttpStatus.OK);
+  }
+
 }

--- a/src/main/java/api/dashboard/utilities/searches/AcessoDadosVeiculos.java
+++ b/src/main/java/api/dashboard/utilities/searches/AcessoDadosVeiculos.java
@@ -5,6 +5,8 @@ import api.dashboard.utilities.GeracaoDatas;
 import api.dashboard.utilities.interfaces.searches.AcessoDados;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+
 @Component
 public class AcessoDadosVeiculos implements AcessoDados {
 
@@ -26,7 +28,10 @@ public class AcessoDadosVeiculos implements AcessoDados {
 
   @Override
   public Integer getRegistrosCadastradosMesEspecifico(Integer valorMes) {
-    return null;
+    LocalDate primeiroDiaDoMes = GeracaoDatas.getDataPersonalizada(GeracaoDatas.getAnoAtual(), valorMes, 01);
+    LocalDate ultimoDiaDoMes = GeracaoDatas.getUltimoDiaMes(primeiroDiaDoMes);
+
+    return repository.countVeiculoBetween2Dates(primeiroDiaDoMes, ultimoDiaDoMes);
   }
 
 }

--- a/src/test/java/api/dashboard/integrationtests/controllers/VeiculoRestControllerTest.java
+++ b/src/test/java/api/dashboard/integrationtests/controllers/VeiculoRestControllerTest.java
@@ -1,6 +1,7 @@
 package api.dashboard.integrationtests.controllers;
 
 import api.dashboard.configs.TestConfigs;
+import api.dashboard.exceptions.ExceptionResponse;
 import api.dashboard.integrationtests.testcontainers.AbstractIntegrationTests;
 import api.dashboard.model.dtos.response.EstatisticasDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -10,6 +11,7 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -19,8 +21,8 @@ import static io.restassured.RestAssured.*;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class VeiculoRestControllerTest extends AbstractIntegrationTests {
 
-  private RequestSpecification specification;
-  private ObjectMapper mapper;
+  private static RequestSpecification specification;
+  private static ObjectMapper mapper;
 
   @BeforeEach
   void setUp() {
@@ -64,4 +66,60 @@ class VeiculoRestControllerTest extends AbstractIntegrationTests {
     Sendo assim, o calculo ficaria (veiculosCadastradosUltimoMes * 100) / totalVeiculos = 20.0
     */
   }
+
+  @Test
+  @Order(2)
+  void getEstatisticasVeiculosByMes() throws JsonProcessingException {
+    var content = given().spec(specification)
+            .basePath("/api/veiculos/buscas/getEstatisticasVeiculosByMes")
+            .param("mes", 1)
+            .when()
+              .get()
+            .then()
+              .statusCode(200)
+            .extract()
+              .body()
+                .asString();
+
+    var response = mapper.readValue(content, EstatisticasDTO.class);
+    response.setCrescimento(-33.333333333333336d);
+
+    assertEquals(EstatisticasDTO.class, response.getClass());
+    assertEquals("Veículos", response.getNomeEntidade());
+    assertEquals(15, response.getTotal());
+    assertEquals(-33.333333333333336d, response.getCrescimento());
+    /*
+    Para realizar o calculo do crescimento, a API busca os registros cadastrados nos ultimos 30 dias no banco de dados
+    Ou seja, se eu chamar esse endpoint hoje (23/04/2024), a API busca registros cadastrados de 23/03/2024 - hoje.
+    Se eu rodar daqui 1 mes, o range de datas muda, fazendo com que o valor retornado mude e o resultado do calculo
+    fique diferente, alterando também o valor do crescimento.
+    Para isso, peguei valores de hoje e setei estaticamente no teste.
+    Veículos cadastradas no mês 1 = 15
+    Veículos buscados de 23/03/2024 - hoje = 10
+    Crescimento dos ultimos 30 dias em relação ao mês 1 = -33.333333333333336%
+    */
+  }
+
+  @Test
+  @Order(3)
+  void getEstatisticasVeiculosByMesThrownZeroCountException() throws JsonProcessingException {
+    var content = given().spec(specification)
+            .basePath("/api/veiculos/buscas/getEstatisticasVeiculosByMes")
+            .param("mes", 5)
+            .when()
+              .get()
+            .then()
+              .statusCode(404)
+            .extract()
+              .body()
+                .asString();
+
+    var response = mapper.readValue(content, ExceptionResponse.class);
+
+    assertEquals(ExceptionResponse.class, response.getClass());
+    assertEquals(HttpStatus.NOT_FOUND.value(), response.getCodigoHttpErro());
+    assertEquals("Dados insuficientes!", response.getMensagemErro());
+    assertEquals("uri=/api/veiculos/buscas/getEstatisticasVeiculosByMes", response.getDetalhesErro());
+  }
+
 }

--- a/src/test/java/api/dashboard/unittests/services/VeiculoServiceImplTest.java
+++ b/src/test/java/api/dashboard/unittests/services/VeiculoServiceImplTest.java
@@ -1,5 +1,6 @@
 package api.dashboard.unittests.services;
 
+import api.dashboard.exceptions.ZeroCountException;
 import api.dashboard.model.dtos.response.EstatisticasDTO;
 import api.dashboard.model.services.impl.VeiculoServiceImpl;
 import api.dashboard.utilities.searches.AcessoDadosVeiculos;
@@ -43,6 +44,39 @@ class VeiculoServiceImplTest {
     assertEquals(50, content.getBody().getTotal());
     // O calculo do crescimento é: (registrosCadastradosUltimoMes * 100) / totalRegistros
     assertEquals(20.0d, content.getBody().getCrescimento());
+  }
+
+  @Test
+  void whenGetEstatisticasVeiculosByMesThenReturnSuccess() {
+    when(acessoDadosVeiculos.getRegistrosCadastradosUltimoMes()).thenReturn(10);
+    when(acessoDadosVeiculos.getRegistrosCadastradosMesEspecifico(anyInt())).thenReturn(15);
+    var content = service.getEstatisticasVeiculosByMes(1);
+
+    assertEquals(HttpStatus.OK, content.getStatusCode());
+    assertEquals(EstatisticasDTO.class, content.getBody().getClass());
+    assertEquals("Veículos", content.getBody().getNomeEntidade());
+    assertEquals(15, content.getBody().getTotal());
+    // O calculo do crescimento é: ((totalCadastrosUltimoMes - totalCadastrosMesEspecifico) * 100) / totalCadastrosMesEspecifico
+    assertEquals(-33.333333333333336d, content.getBody().getCrescimento());
+  }
+
+  @Test
+  void whenGetEstatisticasVeiculosByMesThenThrownZeroCountException() {
+    when(acessoDadosVeiculos.getRegistrosCadastradosUltimoMes()).thenReturn(10);
+    when(acessoDadosVeiculos.getRegistrosCadastradosMesEspecifico(anyInt())).thenReturn(0);
+
+    try {
+      service.getEstatisticasVeiculosByMes(5);
+    } catch (Exception ex) {
+      assertEquals(ZeroCountException.class, ex.getClass());
+      assertEquals("Dados insuficientes!", ex.getMessage());
+    }
+
+    /*
+    A exception é lançada sempre que o total de veiculos cadastrados no mês filtrado for igual a 0.
+    Neste caso é impossivel calcular o crescimento de cadastros.
+    */
+
   }
 
   public void startEntities() {}


### PR DESCRIPTION
Nessa branch foram criados o endpoint getEstatisticasVeiculosByMes, os testes unitários e de integração do endpoint e a documentação.
O endpoint é chamado com intuito de retornar ao usuário dados de veiculos como:
Total de veiculos cadastrados em um mês especifico (selecionado pelo usuário);
Crescimento de cadastros de veiculos no mês atual (ultimos 30 ou 31 dias) em relação a quantidade de cadastros realizados no mês filtrado.
Os testes validam todas as possiveis responses que o endpoint pode retornar ao ser chamado.