### PR TITLE
Feature/criando endpoint get resumo vendas mensais

### DIFF
--- a/src/main/java/api/dashboard/controllers/VendaRestController.java
+++ b/src/main/java/api/dashboard/controllers/VendaRestController.java
@@ -2,6 +2,7 @@ package api.dashboard.controllers;
 
 import api.dashboard.exceptions.ExceptionResponse;
 import api.dashboard.model.dtos.response.EstatisticasDTO;
+import api.dashboard.model.dtos.response.ResumoCadastrosMesDTO;
 import api.dashboard.model.services.impl.VendaServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -14,6 +15,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("api/vendas")
@@ -82,6 +85,11 @@ public class VendaRestController {
           @RequestParam(name = "mes", defaultValue = "1") Integer mes) {
 
     return service.getEstatisticasVendasByMes(mes);
+  }
+
+  @GetMapping("/buscas/getResumoVendasMensais")
+  public ResponseEntity<List<ResumoCadastrosMesDTO>> getResumoVendasMensais() {
+    return service.getResumoVendasMensais();
   }
 
 }

--- a/src/main/java/api/dashboard/controllers/VendaRestController.java
+++ b/src/main/java/api/dashboard/controllers/VendaRestController.java
@@ -5,6 +5,7 @@ import api.dashboard.model.dtos.response.EstatisticasDTO;
 import api.dashboard.model.dtos.response.ResumoCadastrosMesDTO;
 import api.dashboard.model.services.impl.VendaServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -87,6 +88,24 @@ public class VendaRestController {
     return service.getEstatisticasVendasByMes(mes);
   }
 
+  @Operation(summary = "Coletar total de vendas mensais",
+    description = "Coletar o total de vendas cadastradas em cada mês do ano atual",
+    tags = {"Busca"},
+    responses = {
+      @ApiResponse(description = "Sucesso", responseCode = "200",
+        content = {
+          @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            array = @ArraySchema(schema = @Schema(implementation = ResumoCadastrosMesDTO.class))
+          )
+        }
+      ),
+      @ApiResponse(description = "Bad Request", responseCode = "400", content = @Content),
+      @ApiResponse(description = "Unauthorized", responseCode = "401", content = @Content),
+      @ApiResponse(description = "Forbiden", responseCode = "403", content = @Content),
+      @ApiResponse(description = "Internal Server Error", responseCode = "500", content = @Content)
+    }
+  )
   @GetMapping("/buscas/getResumoVendasMensais")
   public ResponseEntity<List<ResumoCadastrosMesDTO>> getResumoVendasMensais() {
     return service.getResumoVendasMensais();

--- a/src/main/java/api/dashboard/model/dtos/response/ResumoCadastrosMesDTO.java
+++ b/src/main/java/api/dashboard/model/dtos/response/ResumoCadastrosMesDTO.java
@@ -1,0 +1,24 @@
+package api.dashboard.model.dtos.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResumoCadastrosMesDTO {
+
+  private String labelMes;
+  private Integer totalCadastros;
+
+  public static ResumoCadastrosMesDTO newResumoCadastrosMesDTO(String labelMes, Integer totalCadastros) {
+    return ResumoCadastrosMesDTO.builder()
+            .labelMes(labelMes)
+            .totalCadastros(totalCadastros)
+            .build();
+  }
+
+}

--- a/src/main/java/api/dashboard/model/services/VendaService.java
+++ b/src/main/java/api/dashboard/model/services/VendaService.java
@@ -1,11 +1,15 @@
 package api.dashboard.model.services;
 
 import api.dashboard.model.dtos.response.EstatisticasDTO;
+import api.dashboard.model.dtos.response.ResumoCadastrosMesDTO;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 public interface VendaService {
 
   ResponseEntity<EstatisticasDTO> getEstatisticasVendas();
   ResponseEntity<EstatisticasDTO> getEstatisticasVendasByMes(Integer valorMes);
+  ResponseEntity<List<ResumoCadastrosMesDTO>> getResumoVendasMensais();
 
 }

--- a/src/main/java/api/dashboard/model/services/impl/VendaServiceImpl.java
+++ b/src/main/java/api/dashboard/model/services/impl/VendaServiceImpl.java
@@ -1,24 +1,31 @@
 package api.dashboard.model.services.impl;
 
 import api.dashboard.model.dtos.response.EstatisticasDTO;
+import api.dashboard.model.dtos.response.ResumoCadastrosMesDTO;
 import api.dashboard.model.services.VendaService;
 import api.dashboard.utilities.Calculos;
+import api.dashboard.utilities.LogicaGetResumoCadastrosMensais;
 import api.dashboard.utilities.searches.AcessoDadosVendas;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class VendaServiceImpl implements VendaService {
 
   private AcessoDadosVendas acessoDadosVendas;
   private Calculos calculos;
+  private LogicaGetResumoCadastrosMensais logicaGetResumoCadastrosMensais;
 
   public VendaServiceImpl(AcessoDadosVendas acessoDadosVendas,
-                          Calculos calculos) {
+                          Calculos calculos,
+                          LogicaGetResumoCadastrosMensais logicaGetResumoCadastrosMensais) {
 
     this.acessoDadosVendas = acessoDadosVendas;
     this.calculos = calculos;
+    this.logicaGetResumoCadastrosMensais = logicaGetResumoCadastrosMensais;
   }
 
   @Override
@@ -41,6 +48,13 @@ public class VendaServiceImpl implements VendaService {
             "Vendas", totalVendas, porcentagemCrescimentoUltimoMesEmRelacaoAoMesSelecionado);
 
     return new ResponseEntity<>(estatisticasDTO, HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<List<ResumoCadastrosMesDTO>> getResumoVendasMensais() {
+    List<ResumoCadastrosMesDTO> resumoCadastrosMesDTOsList = logicaGetResumoCadastrosMensais
+            .getResumoCadastrosMensais(acessoDadosVendas);
+    return new ResponseEntity<>(resumoCadastrosMesDTOsList, HttpStatus.OK);
   }
 
 }

--- a/src/main/java/api/dashboard/utilities/LogicaGetResumoCadastrosMensais.java
+++ b/src/main/java/api/dashboard/utilities/LogicaGetResumoCadastrosMensais.java
@@ -1,0 +1,45 @@
+package api.dashboard.utilities;
+
+import api.dashboard.model.dtos.response.ResumoCadastrosMesDTO;
+import api.dashboard.utilities.interfaces.LogicaGetResumoCadastrosMensaisInterface;
+import api.dashboard.utilities.interfaces.searches.AcessoDados;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Component
+public class LogicaGetResumoCadastrosMensais implements LogicaGetResumoCadastrosMensaisInterface {
+
+  private List<String> mesesDoAno = new ArrayList<>(Arrays
+          .asList("Jan", "Fev", "Mar", "Abr", "Mai", "Jun",
+                  "Jul", "Ago", "Set", "Out", "Nov", "Dez"));
+  private List<ResumoCadastrosMesDTO> resumoCadastrosMesDTOsList = new ArrayList<>();
+
+  @Override
+  public List<ResumoCadastrosMesDTO> getResumoCadastrosMensais(AcessoDados acessoDados) {
+    IntStream.range(1, mesesDoAno.size() + 1).forEach(index -> {
+      String mes = coletarMes(index);
+      Integer totalCadastros = coletarTotalDeCadastros(acessoDados, index);
+      instanciarResumoCadastrosMesDTOEInserirNaLista(mes, totalCadastros);
+    });
+
+    return resumoCadastrosMesDTOsList;
+  }
+
+  private String coletarMes(Integer index) {
+    return mesesDoAno.get(index - 1);
+  }
+
+  private Integer coletarTotalDeCadastros(AcessoDados acessoDados, Integer index) {
+    return acessoDados.getRegistrosCadastradosMesEspecifico(index);
+  }
+
+  private void instanciarResumoCadastrosMesDTOEInserirNaLista(String mes, Integer totalCadastros) {
+    ResumoCadastrosMesDTO resumoCadastrosMesDTO = ResumoCadastrosMesDTO.newResumoCadastrosMesDTO(mes, totalCadastros);
+    resumoCadastrosMesDTOsList.add(resumoCadastrosMesDTO);
+  }
+
+}

--- a/src/main/java/api/dashboard/utilities/interfaces/LogicaGetResumoCadastrosMensaisInterface.java
+++ b/src/main/java/api/dashboard/utilities/interfaces/LogicaGetResumoCadastrosMensaisInterface.java
@@ -1,0 +1,12 @@
+package api.dashboard.utilities.interfaces;
+
+import api.dashboard.model.dtos.response.ResumoCadastrosMesDTO;
+import api.dashboard.utilities.interfaces.searches.AcessoDados;
+
+import java.util.List;
+
+public interface LogicaGetResumoCadastrosMensaisInterface {
+
+  List<ResumoCadastrosMesDTO> getResumoCadastrosMensais(AcessoDados acessoDados);
+
+}

--- a/src/test/java/api/dashboard/integrationtests/controllers/VendaRestControllerTest.java
+++ b/src/test/java/api/dashboard/integrationtests/controllers/VendaRestControllerTest.java
@@ -4,7 +4,9 @@ import api.dashboard.configs.TestConfigs;
 import api.dashboard.exceptions.ExceptionResponse;
 import api.dashboard.integrationtests.testcontainers.AbstractIntegrationTests;
 import api.dashboard.model.dtos.response.EstatisticasDTO;
+import api.dashboard.model.dtos.response.ResumoCadastrosMesDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.builder.RequestSpecBuilder;
@@ -13,6 +15,9 @@ import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static io.restassured.RestAssured.*;
@@ -125,6 +130,28 @@ class VendaRestControllerTest extends AbstractIntegrationTests {
     do crescimento for feito, uma divisão por esse valor é realizada. Se ele for igual a 0, dá erro de divisão por 0.
     Para o usuário não dar de cara com o erro de calculo, a exception informando que não há dados suficientes é lançada.
     */
+  }
+
+  @Test
+  @Order(4)
+  void getResumoVendasMensais() throws JsonProcessingException {
+    var content = given().spec(specification)
+            .basePath("/api/vendas/buscas/getResumoVendasMensais")
+            .when()
+              .get()
+            .then()
+              .statusCode(200)
+            .extract()
+              .body()
+                .asString();
+
+    var response = mapper.readValue(content, new TypeReference<List<ResumoCadastrosMesDTO>>() {});
+
+    assertEquals(ArrayList.class, response.getClass());
+    assertEquals(12, response.size());
+    assertEquals(ResumoCadastrosMesDTO.class, response.get(0).getClass());
+    assertEquals("Jan", response.get(0).getLabelMes());
+    assertEquals(8, response.get(0).getTotalCadastros());
   }
 
 }

--- a/src/test/java/api/dashboard/unittests/services/VendaServiceImplTest.java
+++ b/src/test/java/api/dashboard/unittests/services/VendaServiceImplTest.java
@@ -2,8 +2,10 @@ package api.dashboard.unittests.services;
 
 import api.dashboard.exceptions.ZeroCountException;
 import api.dashboard.model.dtos.response.EstatisticasDTO;
+import api.dashboard.model.dtos.response.ResumoCadastrosMesDTO;
 import api.dashboard.model.services.impl.VendaServiceImpl;
 import api.dashboard.utilities.Calculos;
+import api.dashboard.utilities.LogicaGetResumoCadastrosMensais;
 import api.dashboard.utilities.searches.AcessoDadosVendas;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +16,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -28,6 +34,10 @@ class VendaServiceImplTest {
   private AcessoDadosVendas acessoDadosVendas;
   @Mock
   private Calculos calculos;
+  @Mock
+  private LogicaGetResumoCadastrosMensais logicaGetResumoCadastrosMensais;
+
+  private List<ResumoCadastrosMesDTO> resumoCadastrosMesDTOsList;
 
   @BeforeEach
   void setUp() {
@@ -81,6 +91,26 @@ class VendaServiceImplTest {
     */
   }
 
-  public void startEntities() {}
+  @Test
+  void whenGetResumoVendasMensaisThenReturnSuccess() {
+    /*
+    No teste, a lista passada só contem 1 objeto ResumoCadastrosMesDTO. Em um cenário real, a lista terá um objeto
+    representando cada mês e o total de vendas cadastradas naquele mês.
+    */
+    when(logicaGetResumoCadastrosMensais.getResumoCadastrosMensais(any()))
+            .thenReturn(resumoCadastrosMesDTOsList);
+
+    var content = service.getResumoVendasMensais();
+
+    assertEquals(HttpStatus.OK, content.getStatusCode());
+    assertEquals(ResumoCadastrosMesDTO.class, content.getBody().get(0).getClass());
+    assertEquals("Jan", content.getBody().get(0).getLabelMes());
+    assertEquals(8, content.getBody().get(0).getTotalCadastros());
+  }
+
+  public void startEntities() {
+    resumoCadastrosMesDTOsList =
+            Arrays.asList(ResumoCadastrosMesDTO.newResumoCadastrosMesDTO("Jan", 8));
+  }
 
 }


### PR DESCRIPTION
Nessa branch criei o endpoint getResumoVendasMensais, os testes de integração e unitário e a documentação do endpoint.
Pela complexidade do endpoint ser um pouco maior, criei uma classe somente para desenvolver a lógica. A classe é generica e pode ser usada posteriormente para outras entidades.

O endpoint é chamado pelo usuário que deseja saber quantas vendas foram cadastradas em cada mês do ano atual.
Ele retorna uma lista contendo objetos com 2 atributos: Nome do mês e total de vendas cadastradas.
O endpoint foi criado a principio para que a lista seja usada na geração de um gráfico de vendas no front-end.