### PR TITLE
Feature/criando endpoint cadastrar cliente

### DIFF
--- a/src/main/java/api/dashboard/controllers/ClienteRestController.java
+++ b/src/main/java/api/dashboard/controllers/ClienteRestController.java
@@ -85,6 +85,32 @@ public class ClienteRestController {
     return service.getEstatisticasClientesByMes(mes);
   }
 
+  @Operation(summary = "Cadastrar novo cliente",
+    description = "Cadastrar novo cliente e numero de telefone do cliente no banco de dados.",
+    tags = {"Cadastro"},
+    responses = {
+      @ApiResponse(description = "Sucesso", responseCode = "201",
+        content = {
+          @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ClienteResponseDTO.class)
+          )
+        }
+      ),
+      @ApiResponse(description = "CPF, número de telefone ou email já existente no banco de dados", responseCode = "409",
+        content = {
+          @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ExceptionResponse.class)
+          )
+        }
+      ),
+      @ApiResponse(description = "Bad Request", responseCode = "400", content = @Content),
+      @ApiResponse(description = "Unauthorized", responseCode = "401", content = @Content),
+      @ApiResponse(description = "Forbiden", responseCode = "403", content = @Content),
+      @ApiResponse(description = "Internal Server Error", responseCode = "500", content = @Content)
+    }
+  )
   @PostMapping("/persistencias/cadastrarCliente")
   public ResponseEntity<ClienteResponseDTO> cadastrarCliente(@RequestBody ClienteRequestDTO clienteRequestDTO) {
     return service.cadastrarCliente(clienteRequestDTO);

--- a/src/main/java/api/dashboard/controllers/ClienteRestController.java
+++ b/src/main/java/api/dashboard/controllers/ClienteRestController.java
@@ -1,6 +1,8 @@
 package api.dashboard.controllers;
 
 import api.dashboard.exceptions.ExceptionResponse;
+import api.dashboard.model.dtos.request.ClienteRequestDTO;
+import api.dashboard.model.dtos.response.ClienteResponseDTO;
 import api.dashboard.model.dtos.response.EstatisticasDTO;
 import api.dashboard.model.services.impl.ClienteServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,10 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/clientes")
@@ -84,6 +83,11 @@ public class ClienteRestController {
   ) {
 
     return service.getEstatisticasClientesByMes(mes);
+  }
+
+  @PostMapping("/persistencias/cadastrarCliente")
+  public ResponseEntity<ClienteResponseDTO> cadastrarCliente(@RequestBody ClienteRequestDTO clienteRequestDTO) {
+    return service.cadastrarCliente(clienteRequestDTO);
   }
 
 }

--- a/src/main/java/api/dashboard/exceptions/ConflictException.java
+++ b/src/main/java/api/dashboard/exceptions/ConflictException.java
@@ -1,0 +1,9 @@
+package api.dashboard.exceptions;
+
+public class ConflictException extends RuntimeException {
+
+  public ConflictException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/api/dashboard/exceptions/controllers/ExceptionHandlerController.java
+++ b/src/main/java/api/dashboard/exceptions/controllers/ExceptionHandlerController.java
@@ -1,5 +1,6 @@
 package api.dashboard.exceptions.controllers;
 
+import api.dashboard.exceptions.ConflictException;
 import api.dashboard.exceptions.ExceptionResponse;
 import api.dashboard.exceptions.ZeroCountException;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,11 @@ public class ExceptionHandlerController extends ResponseEntityExceptionHandler {
   @ExceptionHandler(ZeroCountException.class)
   public ResponseEntity<ExceptionResponse> zeroCountException(Exception ex, WebRequest request) {
     return criarERetornarExceptionResponse(ex, request, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(ConflictException.class)
+  public ResponseEntity<ExceptionResponse> conflictException(Exception ex, WebRequest request) {
+    return criarERetornarExceptionResponse(ex, request, HttpStatus.CONFLICT);
   }
 
   public ResponseEntity<ExceptionResponse> criarERetornarExceptionResponse(Exception ex,

--- a/src/main/java/api/dashboard/model/dtos/request/ClienteRequestDTO.java
+++ b/src/main/java/api/dashboard/model/dtos/request/ClienteRequestDTO.java
@@ -1,0 +1,25 @@
+package api.dashboard.model.dtos.request;
+
+import api.dashboard.enums.Genero;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClienteRequestDTO {
+
+  private String primeiroNome;
+  private String sobrenome;
+  private String cpf;
+  private LocalDate dataNascimento;
+  private Genero genero;
+  private String email;
+  private TelefoneRequestDTO telefoneRequestDTO;
+
+}

--- a/src/main/java/api/dashboard/model/dtos/request/TelefoneRequestDTO.java
+++ b/src/main/java/api/dashboard/model/dtos/request/TelefoneRequestDTO.java
@@ -1,0 +1,17 @@
+package api.dashboard.model.dtos.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TelefoneRequestDTO {
+
+  private String ddd;
+  private String numero;
+
+}

--- a/src/main/java/api/dashboard/model/dtos/response/ClienteResponseDTO.java
+++ b/src/main/java/api/dashboard/model/dtos/response/ClienteResponseDTO.java
@@ -1,0 +1,26 @@
+package api.dashboard.model.dtos.response;
+
+import api.dashboard.enums.Genero;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.hateoas.RepresentationModel;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClienteResponseDTO extends RepresentationModel<ClienteResponseDTO> {
+
+  private Long id;
+  private String primeiroNome;
+  private String sobrenome;
+  private String cpf;
+  private LocalDate dataNascimento;
+  private Genero genero;
+  private String email;
+
+}

--- a/src/main/java/api/dashboard/model/repositories/ClienteRepository.java
+++ b/src/main/java/api/dashboard/model/repositories/ClienteRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 @Repository
 public interface ClienteRepository extends JpaRepository<Cliente, Long> {
@@ -23,4 +24,8 @@ public interface ClienteRepository extends JpaRepository<Cliente, Long> {
           "AND c.dataCriacao <= :dataFinal")
   Integer countClienteBetween2Dates(@PathParam("dataInicio") LocalDate dataInicial,
                                     @PathParam("dataFinal") LocalDate dataFinal);
+
+  Optional<Cliente> findByCpf(String cpf);
+  Optional<Cliente> findByEmail(String email);
+
 }

--- a/src/main/java/api/dashboard/model/repositories/TelefoneRepository.java
+++ b/src/main/java/api/dashboard/model/repositories/TelefoneRepository.java
@@ -4,5 +4,11 @@ import api.dashboard.model.entities.Telefone;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface TelefoneRepository extends JpaRepository<Telefone, Long> { }
+public interface TelefoneRepository extends JpaRepository<Telefone, Long> {
+
+  Optional<Telefone> findByNumero(String numero);
+
+}

--- a/src/main/java/api/dashboard/model/services/ClienteService.java
+++ b/src/main/java/api/dashboard/model/services/ClienteService.java
@@ -1,5 +1,7 @@
 package api.dashboard.model.services;
 
+import api.dashboard.model.dtos.request.ClienteRequestDTO;
+import api.dashboard.model.dtos.response.ClienteResponseDTO;
 import api.dashboard.model.dtos.response.EstatisticasDTO;
 import org.springframework.http.ResponseEntity;
 
@@ -7,5 +9,6 @@ public interface ClienteService {
 
   ResponseEntity<EstatisticasDTO> getEstatisticasClientes();
   ResponseEntity<EstatisticasDTO> getEstatisticasClientesByMes(Integer valorMes);
+  ResponseEntity<ClienteResponseDTO> cadastrarCliente(ClienteRequestDTO clienteRequestDTO);
 
 }

--- a/src/main/java/api/dashboard/model/services/impl/ClienteServiceImpl.java
+++ b/src/main/java/api/dashboard/model/services/impl/ClienteServiceImpl.java
@@ -1,8 +1,13 @@
 package api.dashboard.model.services.impl;
 
+import api.dashboard.model.dtos.request.ClienteRequestDTO;
+import api.dashboard.model.dtos.response.ClienteResponseDTO;
 import api.dashboard.model.dtos.response.EstatisticasDTO;
+import api.dashboard.model.entities.Cliente;
+import api.dashboard.model.entities.Telefone;
 import api.dashboard.model.services.ClienteService;
 import api.dashboard.utilities.Calculos;
+import api.dashboard.utilities.businessLogicEndpoints.clientes.LogicaCadastrarCliente;
 import api.dashboard.utilities.searches.AcessoDadosClientes;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,12 +18,15 @@ public class ClienteServiceImpl implements ClienteService {
 
   private AcessoDadosClientes acessoDadosClientes;
   private Calculos calculos;
+  private LogicaCadastrarCliente logicaCadastrarCliente;
 
   public ClienteServiceImpl(AcessoDadosClientes acessoDadosClientes,
-                            Calculos calculos) {
+                            Calculos calculos,
+                            LogicaCadastrarCliente logicaCadastrarCliente) {
 
     this.acessoDadosClientes = acessoDadosClientes;
     this.calculos = calculos;
+    this.logicaCadastrarCliente = logicaCadastrarCliente;
   }
 
   @Override
@@ -41,6 +49,17 @@ public class ClienteServiceImpl implements ClienteService {
             "Clientes", totalClientes, porcentagemCrescimentoUltimoMesEmRelacaoAoMesSelecionado);
 
     return new ResponseEntity<>(estatisticasDTO, HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<ClienteResponseDTO> cadastrarCliente(ClienteRequestDTO clienteRequestDTO) {
+    logicaCadastrarCliente.validarClienteRequestDTO(clienteRequestDTO);
+    Telefone telefone = logicaCadastrarCliente.criarESalvarTelefoneDoCliente(clienteRequestDTO.getTelefoneRequestDTO());
+    Cliente cliente = logicaCadastrarCliente.criarESalvarCliente(clienteRequestDTO, telefone);
+    logicaCadastrarCliente.vincularTelefoneAoCliente(telefone, cliente);
+    ClienteResponseDTO clienteResponseDTO = logicaCadastrarCliente.criarLinksHateoasDeCliente(cliente);
+
+    return new ResponseEntity<>(clienteResponseDTO, HttpStatus.CREATED);
   }
 
 }

--- a/src/main/java/api/dashboard/model/services/impl/VendaServiceImpl.java
+++ b/src/main/java/api/dashboard/model/services/impl/VendaServiceImpl.java
@@ -4,7 +4,7 @@ import api.dashboard.model.dtos.response.EstatisticasDTO;
 import api.dashboard.model.dtos.response.ResumoCadastrosMesDTO;
 import api.dashboard.model.services.VendaService;
 import api.dashboard.utilities.Calculos;
-import api.dashboard.utilities.LogicaGetResumoCadastrosMensais;
+import api.dashboard.utilities.businessLogicEndpoints.vendas.LogicaGetResumoCadastrosMensais;
 import api.dashboard.utilities.searches.AcessoDadosVendas;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/api/dashboard/utilities/businessLogicEndpoints/clientes/LogicaCadastrarCliente.java
+++ b/src/main/java/api/dashboard/utilities/businessLogicEndpoints/clientes/LogicaCadastrarCliente.java
@@ -1,0 +1,58 @@
+package api.dashboard.utilities.businessLogicEndpoints.clientes;
+
+import api.dashboard.dozermapper.DozzerMapper;
+import api.dashboard.model.dtos.request.ClienteRequestDTO;
+import api.dashboard.model.dtos.request.TelefoneRequestDTO;
+import api.dashboard.model.dtos.response.ClienteResponseDTO;
+import api.dashboard.model.entities.Cliente;
+import api.dashboard.model.entities.Telefone;
+import api.dashboard.model.repositories.ClienteRepository;
+import api.dashboard.model.repositories.TelefoneRepository;
+import api.dashboard.validations.ValidacaoCliente;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class LogicaCadastrarCliente {
+
+  private ValidacaoCliente validacaoCliente;
+  private ClienteRepository clienteRepository;
+  private TelefoneRepository telefoneRepository;
+
+  public LogicaCadastrarCliente(ValidacaoCliente validacaoCliente,
+                                ClienteRepository clienteRepository,
+                                TelefoneRepository telefoneRepository) {
+
+    this.validacaoCliente = validacaoCliente;
+    this.clienteRepository = clienteRepository;
+    this.telefoneRepository = telefoneRepository;
+  }
+
+  public void validarClienteRequestDTO(ClienteRequestDTO clienteRequestDTO) {
+    validacaoCliente.validar(clienteRequestDTO);
+  }
+
+  public Telefone criarESalvarTelefoneDoCliente(TelefoneRequestDTO telefoneRequestDTO) {
+    Telefone telefone = DozzerMapper.parseObject(telefoneRequestDTO, Telefone.class);
+    return telefoneRepository.save(telefone);
+  }
+
+  public Cliente criarESalvarCliente(ClienteRequestDTO clienteRequestDTO, Telefone telefone) {
+    Cliente cliente = DozzerMapper.parseObject(clienteRequestDTO, Cliente.class);
+    cliente.setTelefone(telefone);
+    cliente.setDataCriacao(LocalDate.now());
+    return clienteRepository.save(cliente);
+  }
+
+  public void vincularTelefoneAoCliente(Telefone telefone, Cliente cliente) {
+    telefone.setCliente(cliente);
+  }
+
+  public ClienteResponseDTO criarLinksHateoasDeCliente(Cliente cliente) {
+    ClienteResponseDTO clienteResponseDTO = DozzerMapper.parseObject(cliente, ClienteResponseDTO.class);
+    // TODO Criar links HATEOAS de telefone
+    return clienteResponseDTO;
+  }
+
+}

--- a/src/main/java/api/dashboard/utilities/businessLogicEndpoints/vendas/LogicaGetResumoCadastrosMensais.java
+++ b/src/main/java/api/dashboard/utilities/businessLogicEndpoints/vendas/LogicaGetResumoCadastrosMensais.java
@@ -1,4 +1,4 @@
-package api.dashboard.utilities;
+package api.dashboard.utilities.businessLogicEndpoints.vendas;
 
 import api.dashboard.model.dtos.response.ResumoCadastrosMesDTO;
 import api.dashboard.utilities.interfaces.LogicaGetResumoCadastrosMensaisInterface;

--- a/src/main/java/api/dashboard/validations/ValidacaoCliente.java
+++ b/src/main/java/api/dashboard/validations/ValidacaoCliente.java
@@ -1,0 +1,46 @@
+package api.dashboard.validations;
+
+import api.dashboard.exceptions.ConflictException;
+import api.dashboard.model.dtos.request.ClienteRequestDTO;
+import api.dashboard.model.repositories.ClienteRepository;
+import api.dashboard.model.repositories.TelefoneRepository;
+import api.dashboard.validations.interfaces.Validacao;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ValidacaoCliente implements Validacao<ClienteRequestDTO> {
+
+  private ClienteRepository clienteRepository;
+  private TelefoneRepository telefoneRepository;
+
+  public ValidacaoCliente(ClienteRepository clienteRepository,
+                          TelefoneRepository telefoneRepository) {
+
+    this.clienteRepository = clienteRepository;
+    this.telefoneRepository = telefoneRepository;
+  }
+
+  @Override
+  public void validar(ClienteRequestDTO objeto) {
+    validarCPF(objeto);
+    validarTelefone(objeto);
+    validarEmail(objeto);
+  }
+
+  private void validarCPF(ClienteRequestDTO clienteRequestDTO) {
+    if (clienteRepository.findByCpf(clienteRequestDTO.getCpf()).isPresent())
+      throw new ConflictException("Verificamos que já existem clientes cadastrados com este CPF!");
+  }
+
+  private void validarTelefone(ClienteRequestDTO clienteRequestDTO) {
+    String numeroTelefoneCliente = clienteRequestDTO.getTelefoneRequestDTO().getNumero();
+    if (telefoneRepository.findByNumero(numeroTelefoneCliente).isPresent())
+      throw new ConflictException("Verificamos que já existem clientes cadastrados com este número de telefone!");
+  }
+
+  private void validarEmail(ClienteRequestDTO clienteRequestDTO) {
+    if (clienteRepository.findByEmail(clienteRequestDTO.getEmail()).isPresent())
+      throw new ConflictException("Verificamos que já existem clientes cadastrados com este email!");
+  }
+
+}

--- a/src/main/java/api/dashboard/validations/interfaces/Validacao.java
+++ b/src/main/java/api/dashboard/validations/interfaces/Validacao.java
@@ -1,0 +1,7 @@
+package api.dashboard.validations.interfaces;
+
+public interface Validacao<T> {
+
+  void validar(T objeto);
+
+}

--- a/src/test/java/api/dashboard/unittests/services/ClienteServiceImplTest.java
+++ b/src/test/java/api/dashboard/unittests/services/ClienteServiceImplTest.java
@@ -1,9 +1,16 @@
 package api.dashboard.unittests.services;
 
+import api.dashboard.enums.Genero;
 import api.dashboard.exceptions.ZeroCountException;
+import api.dashboard.model.dtos.request.ClienteRequestDTO;
+import api.dashboard.model.dtos.request.TelefoneRequestDTO;
+import api.dashboard.model.dtos.response.ClienteResponseDTO;
 import api.dashboard.model.dtos.response.EstatisticasDTO;
+import api.dashboard.model.entities.Cliente;
+import api.dashboard.model.entities.Telefone;
 import api.dashboard.model.services.impl.ClienteServiceImpl;
 import api.dashboard.utilities.Calculos;
+import api.dashboard.utilities.businessLogicEndpoints.clientes.LogicaCadastrarCliente;
 import api.dashboard.utilities.searches.AcessoDadosClientes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +21,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -27,7 +36,21 @@ class ClienteServiceImplTest {
   @Mock
   private AcessoDadosClientes acessoDadosClientes;
   @Mock
-  Calculos calculos;
+  private Calculos calculos;
+  @Mock
+  private LogicaCadastrarCliente logicaCadastrarCliente;
+
+  private ClienteRequestDTO clienteRequestDTO;
+  private TelefoneRequestDTO telefoneRequestDTO;
+  private Cliente cliente;
+  private Telefone telefone;
+  private ClienteResponseDTO clienteResponseDTO;
+
+  private final String PRIMEIRO_NOME = "Primeiro Nome Teste";
+  private final String SOBRENOME = "Sobrenome Teste";
+  private final String CPF = "00000000000";
+  private final String EMAIL = "emailTeste@email.com";
+
 
   @BeforeEach
   void setUp() {
@@ -81,5 +104,70 @@ class ClienteServiceImplTest {
     */
   }
 
-  public void startEntities() {}
+  @Test
+  void whenCadastrarClienteThenReturnSuccess() {
+    when(logicaCadastrarCliente.criarESalvarTelefoneDoCliente(
+            any(TelefoneRequestDTO.class))).thenReturn(telefone);
+    when(logicaCadastrarCliente.criarESalvarCliente(
+            any(ClienteRequestDTO.class), any(Telefone.class))).thenReturn(cliente);
+    when(logicaCadastrarCliente.criarLinksHateoasDeCliente(
+            any(Cliente.class))).thenReturn(clienteResponseDTO);
+
+    var content = service.cadastrarCliente(clienteRequestDTO);
+
+    assertEquals(HttpStatus.CREATED, content.getStatusCode());
+    assertEquals(ClienteResponseDTO.class, content.getBody().getClass());
+    assertEquals(1L, content.getBody().getId());
+    assertEquals(PRIMEIRO_NOME, content.getBody().getPrimeiroNome());
+    assertEquals(SOBRENOME, content.getBody().getSobrenome());
+    assertEquals(CPF, content.getBody().getCpf());
+    assertEquals(Genero.MASCULINO, content.getBody().getGenero());
+    assertEquals(EMAIL, content.getBody().getEmail());
+    assertEquals(LocalDate.of(2000, 01, 01), content.getBody().getDataNascimento());
+  }
+
+  public void startEntities() {
+    telefoneRequestDTO = TelefoneRequestDTO.builder()
+            .ddd("000")
+            .numero("000000000")
+            .build();
+
+    clienteRequestDTO = ClienteRequestDTO.builder()
+            .primeiroNome(PRIMEIRO_NOME)
+            .sobrenome(SOBRENOME)
+            .cpf(CPF)
+            .genero(Genero.MASCULINO)
+            .email(EMAIL)
+            .dataNascimento(LocalDate.of(2000, 01, 01))
+            .telefoneRequestDTO(telefoneRequestDTO)
+            .build();
+
+    telefone = Telefone.builder()
+            .id(1L)
+            .ddd("000")
+            .numero("000000000")
+            .build();
+
+    cliente = Cliente.builder()
+            .id(1L)
+            .primeiroNome(PRIMEIRO_NOME)
+            .sobrenome(SOBRENOME)
+            .cpf(CPF)
+            .genero(Genero.MASCULINO)
+            .email(EMAIL)
+            .dataNascimento(LocalDate.of(2000, 01, 01))
+            .dataCriacao(LocalDate.of(2024, 01, 01))
+            .telefone(telefone)
+            .build();
+
+    clienteResponseDTO = ClienteResponseDTO.builder()
+            .id(1L)
+            .primeiroNome(PRIMEIRO_NOME)
+            .sobrenome(SOBRENOME)
+            .cpf(CPF)
+            .genero(Genero.MASCULINO)
+            .email(EMAIL)
+            .dataNascimento(LocalDate.of(2000, 01, 01))
+            .build();
+  }
 }

--- a/src/test/java/api/dashboard/unittests/services/VendaServiceImplTest.java
+++ b/src/test/java/api/dashboard/unittests/services/VendaServiceImplTest.java
@@ -5,7 +5,7 @@ import api.dashboard.model.dtos.response.EstatisticasDTO;
 import api.dashboard.model.dtos.response.ResumoCadastrosMesDTO;
 import api.dashboard.model.services.impl.VendaServiceImpl;
 import api.dashboard.utilities.Calculos;
-import api.dashboard.utilities.LogicaGetResumoCadastrosMensais;
+import api.dashboard.utilities.businessLogicEndpoints.vendas.LogicaGetResumoCadastrosMensais;
 import api.dashboard.utilities.searches.AcessoDadosVendas;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,7 +17,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 


### PR DESCRIPTION
Nessa branch foi criado o endpoint cadastrarCliente, os testes e a documentação.

Esse endpoint será utilizado pelo usuário que quiser cadastrar um novo cliente no sistema.
A API recebe os dados pessoais do cliente e tambem seu numero de telefone, a API valida esses dados e, se todos estiverem corretos, ela salva o cliente. Caso hajam dados repetidos no banco de dados, tais como: CPF, numero de telefone ou email, a API retorna um erro ao usuário.

Realizei os testes de integração validando tanto o caso de sucesso, quanto os casos de erros
Criei também os testes unitários.

Documentei o endpoint para auxiliar o front-end quando for consumir a API.