### PR TITLE
Criando link HATEOAS no endpoint cadastrarCliente

### DIFF
--- a/src/main/java/api/dashboard/utilities/businessLogicEndpoints/clientes/LogicaCadastrarCliente.java
+++ b/src/main/java/api/dashboard/utilities/businessLogicEndpoints/clientes/LogicaCadastrarCliente.java
@@ -1,5 +1,6 @@
 package api.dashboard.utilities.businessLogicEndpoints.clientes;
 
+import api.dashboard.controllers.TelefoneRestController;
 import api.dashboard.dozermapper.DozzerMapper;
 import api.dashboard.model.dtos.request.ClienteRequestDTO;
 import api.dashboard.model.dtos.request.TelefoneRequestDTO;
@@ -12,6 +13,7 @@ import api.dashboard.validations.ValidacaoCliente;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
 
 @Component
 public class LogicaCadastrarCliente {
@@ -51,7 +53,8 @@ public class LogicaCadastrarCliente {
 
   public ClienteResponseDTO criarLinksHateoasDeCliente(Cliente cliente) {
     ClienteResponseDTO clienteResponseDTO = DozzerMapper.parseObject(cliente, ClienteResponseDTO.class);
-    // TODO Criar links HATEOAS de telefone
+    clienteResponseDTO.add(linkTo(methodOn(TelefoneRestController.class)
+            .getTelefoneById(cliente.getTelefone().getId())).withRel("Telefone"));
     return clienteResponseDTO;
   }
 

--- a/src/test/java/api/dashboard/integrationtests/controllers/ClienteRestControllerTest.java
+++ b/src/test/java/api/dashboard/integrationtests/controllers/ClienteRestControllerTest.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -162,7 +163,8 @@ class ClienteRestControllerTest extends AbstractIntegrationTests {
     assertEquals(Genero.MASCULINO, response.getGenero());
     assertEquals("emailTeste@email.com", response.getEmail());
     assertEquals(LocalDate.of(2000, 01, 01), response.getDataNascimento());
-    //TODO Inserir validação do link HATEOAS de telefone
+    assertTrue(content.contains(
+            "\"_links\":{\"Telefone\":{\"href\":\"http://localhost:8888/api/telefones/buscas/getTelefoneById/51\"}}"));
   }
 
   @Test


### PR DESCRIPTION
Fiz a inserção do link HATEOAS de telefone para o objeto da response do endpoint cadastrarCliente. Agora, quando o usuário chamar este endpoint, a API irá retornar um clienteResponseDTO contendo os dados pessoais do cliente que foram salvos e, neste objeto, irá ter um link para a URL do endpoint getTelefoneById passando o ID do telefone do cliente que foi salvo. Dessa forma, o usuário poderá consultar o telefone desse cliente que acabou de ser salvo. Fiz também o teste de integração validando a geração desse link.